### PR TITLE
Fixed issue with Proxy project reference not being added to Windows Phone 8.1 project

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <js-module src="www/windows/SqlTransaction.js" name="SqlTransaction" />
 
         <framework src="src/windows/SQLite.Proxy/SQLite.Proxy/SQLite.Proxy.csproj"
-            custom="true" type="projectReference" target="windows" />
+            custom="true" type="projectReference" target="all" />
 
         <js-module src="src/windows/WebSqlProxy.js" name="WebSqlProxy">
             <runs />


### PR DESCRIPTION
Using framework tag' target="all" to cover both Windows 8.0/8.1 and Windows Phone 8.1.

This closes #25 
